### PR TITLE
fix(infra): run deployment scripts within the VNet

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -24,6 +24,7 @@ module virtualNetwork 'modules/virtualNetwork.bicep' = {
     name: '${abbrs.networkVirtualNetworks}${applicationName}'
     tags: tags
     subnetName: '${abbrs.networkVirtualNetworksSubnets}container-apps'
+    deploymentScriptsSubnetName: '${abbrs.networkVirtualNetworksSubnets}deployment-scripts'
   }
   scope: fakeSurveyGeneratorResourceGroup
 }
@@ -72,7 +73,22 @@ module keyVault 'modules/keyVault.bicep' = {
         }
       ]
     }
-    subnetResourceId: virtualNetwork.outputs.subnetId
+    subnetResourceIds: [
+      virtualNetwork.outputs.subnetId
+      virtualNetwork.outputs.deploymentScriptsSubnetId
+    ]
+  }
+  scope: fakeSurveyGeneratorResourceGroup
+}
+
+module deploymentScriptStorage 'modules/deploymentScriptStorage.bicep' = {
+  name: 'deploymentScriptStorage'
+  params: {
+    location: location
+    tags: tags
+    name: take(toLower('${abbrs.storageStorageAccounts}${uniqueString('deployment-scripts', fakeSurveyGeneratorResourceGroup.id)}'), 24)
+    subnetResourceId: virtualNetwork.outputs.deploymentScriptsSubnetId
+    deploymentScriptIdentityPrincipalId: managedIdentity.outputs.principalId
   }
   scope: fakeSurveyGeneratorResourceGroup
 }
@@ -94,6 +110,8 @@ module redisPassword 'modules/redisPassword.bicep' = {
     tags: tags
     name: '${abbrs.managedIdentityUserAssignedIdentities}${applicationName}-redis-password-generator'
     keyVaultName: keyVault.outputs.keyVaultName
+    deploymentScriptStorageAccountName: deploymentScriptStorage.outputs.name
+    deploymentScriptSubnetResourceId: virtualNetwork.outputs.deploymentScriptsSubnetId
   }
   scope: fakeSurveyGeneratorResourceGroup
 }
@@ -120,6 +138,8 @@ module azureSql 'modules/sql.bicep' = {
     azureAdAdministratorLogin: managedIdentity.outputs.identityName
     azureAdAdministratorObjectId: managedIdentity.outputs.principalId
     subnetResourceId: virtualNetwork.outputs.subnetId
+    deploymentScriptStorageAccountName: deploymentScriptStorage.outputs.name
+    deploymentScriptSubnetResourceId: virtualNetwork.outputs.deploymentScriptsSubnetId
     managedIdentityId: managedIdentity.outputs.identityResourceId
     pipelineIdentityClientId: 'df54403d-edea-442f-bc25-99403859119c'
   }

--- a/infra/modules/deploymentScriptStorage.bicep
+++ b/infra/modules/deploymentScriptStorage.bicep
@@ -1,0 +1,56 @@
+@description('Name of the storage account used by VNet-connected deployment scripts')
+param name string
+
+@description('Tags to apply to the resource')
+param tags object
+
+@description('Subnet Resource ID used by deployment-script Azure Container Instances')
+param subnetResourceId string
+
+@description('Principal ID of the user-assigned managed identity used by deployment scripts')
+param deploymentScriptIdentityPrincipalId string
+
+@description('Location for all resources')
+param location string = resourceGroup().location
+
+var storageFileDataPrivilegedContributor = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '69566ab7-960f-475b-8e7c-b3118f30c6bd'
+)
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-06-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: true
+    minimumTlsVersion: 'TLS1_2'
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Deny'
+      virtualNetworkRules: [
+        {
+          id: subnetResourceId
+          action: 'Allow'
+        }
+      ]
+    }
+  }
+}
+
+resource storageFileDataPrivilegedContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, deploymentScriptIdentityPrincipalId, storageFileDataPrivilegedContributor)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: storageFileDataPrivilegedContributor
+    principalId: deploymentScriptIdentityPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output name string = storageAccount.name

--- a/infra/modules/keyVault.bicep
+++ b/infra/modules/keyVault.bicep
@@ -14,8 +14,8 @@ param name string
 @secure()
 param secretsObject object
 
-@description('Subnet Resource ID for the infrastructure subnet')
-param subnetResourceId string
+@description('Subnet Resource IDs permitted to access the Key Vault through a service endpoint')
+param subnetResourceIds array
 
 resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' = {
   name: name
@@ -35,7 +35,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' = {
       defaultAction: 'Deny'
       bypass: 'AzureServices'
       virtualNetworkRules: [
-        {
+        for subnetResourceId in subnetResourceIds: {
           id: subnetResourceId
         }
       ]

--- a/infra/modules/redisPassword.bicep
+++ b/infra/modules/redisPassword.bicep
@@ -10,13 +10,27 @@ param name string
 @description('Name of the Key Vault that stores the Redis password')
 param keyVaultName string
 
+@description('Name of the deployment-script storage account')
+param deploymentScriptStorageAccountName string
+
+@description('Subnet Resource ID used by the deployment-script Azure Container Instance')
+param deploymentScriptSubnetResourceId string
+
 var keyVaultSecretsOfficer = subscriptionResourceId(
   'Microsoft.Authorization/roleDefinitions',
   'b86a8fe4-44ce-4948-aee5-eccb2c155cd7'
 )
+var storageFileDataPrivilegedContributor = subscriptionResourceId(
+  'Microsoft.Authorization/roleDefinitions',
+  '69566ab7-960f-475b-8e7c-b3118f30c6bd'
+)
 
 resource keyVault 'Microsoft.KeyVault/vaults@2025-05-01' existing = {
   name: keyVaultName
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2025-06-01' existing = {
+  name: deploymentScriptStorageAccountName
 }
 
 resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2025-05-31-preview' = {
@@ -30,6 +44,16 @@ resource keyVaultSecretsOfficerRoleAssignment 'Microsoft.Authorization/roleAssig
   scope: keyVault
   properties: {
     roleDefinitionId: keyVaultSecretsOfficer
+    principalId: managedIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource storageFileDataPrivilegedContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, managedIdentity.id, storageFileDataPrivilegedContributor)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: storageFileDataPrivilegedContributor
     principalId: managedIdentity.properties.principalId
     principalType: 'ServicePrincipal'
   }
@@ -50,6 +74,16 @@ resource redisPassword 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
     timeout: 'PT10M'
     retentionInterval: 'PT1H'
     cleanupPreference: 'OnSuccess'
+    storageAccountSettings: {
+      storageAccountName: deploymentScriptStorageAccountName
+    }
+    containerSettings: {
+      subnetIds: [
+        {
+          id: deploymentScriptSubnetResourceId
+        }
+      ]
+    }
     arguments: '${keyVault.properties.vaultUri} RedisPassword'
     scriptContent: '''
       #!/usr/bin/env bash
@@ -71,6 +105,7 @@ resource redisPassword 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
   }
   dependsOn: [
     keyVaultSecretsOfficerRoleAssignment
+    storageFileDataPrivilegedContributorRoleAssignment
   ]
 }
 

--- a/infra/modules/sql-deployment-script.ps1
+++ b/infra/modules/sql-deployment-script.ps1
@@ -1,44 +1,67 @@
-$sqlServerFqdn = "$env:DBSERVER"
-$sqlDatabaseName = "$env:DBNAME"
-$principalName = "$env:PRINCIPALNAME"
-$id = "$env:ID"
-$pipelineIdentityName = "$env:PIPELINEIDENTITYNAME"
-$pipelineIdentityClientId = "$env:PIPELINEIDENTITYCLIENTID"
+$ErrorActionPreference = 'Stop'
 
-# Install SqlServer module - using specific version to avoid breaking changes in 22.4.5.1 (see https://github.com/dotnet/aspire/issues/9926)
-Install-Module -Name SqlServer -RequiredVersion 22.3.0 -Force -AllowClobber -Scope CurrentUser
-Import-Module SqlServer
+$sqlServerFqdn = $env:DBSERVER
+$sqlDatabaseName = $env:DBNAME
+$principalName = $env:PRINCIPALNAME
+$principalId = [Guid]$env:ID
+$pipelineIdentityName = $env:PIPELINEIDENTITYNAME
+$pipelineIdentityClientId = [Guid]$env:PIPELINEIDENTITYCLIENTID
 
-$sqlCmd = @"
-DECLARE @name SYSNAME = '$principalName';
-DECLARE @id UNIQUEIDENTIFIER = '$id';
-DECLARE @pipelineName SYSNAME = '$pipelineIdentityName';
-DECLARE @pipelineId UNIQUEIDENTIFIER = '$pipelineIdentityClientId';
+$sqlAccessToken = Get-AzAccessToken -ResourceUrl 'https://database.windows.net/'
+$tokenBstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlAccessToken.Token)
 
--- Convert the guid to the right type
-DECLARE @castId NVARCHAR(MAX) = CONVERT(VARCHAR(MAX), CONVERT (VARBINARY(16), @id), 1);
-DECLARE @pipelineCastId NVARCHAR(MAX) = CONVERT(VARCHAR(MAX), CONVERT (VARBINARY(16), @pipelineId), 1);
+try {
+    $accessToken = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($tokenBstr)
+}
+finally {
+    [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($tokenBstr)
+}
 
--- Construct command: CREATE USER [@name] WITH SID = @castId, TYPE = E;
-DECLARE @cmd NVARCHAR(MAX) = N'CREATE USER [' + @name + '] WITH SID = ' + @castId + ', TYPE = E;'
-EXEC (@cmd);
+$connection = [System.Data.SqlClient.SqlConnection]::new(
+    "Server=tcp:${sqlServerFqdn},1433;Initial Catalog=${sqlDatabaseName};Encrypt=True;TrustServerCertificate=False;"
+)
+$connection.AccessToken = $accessToken
 
--- Assign roles to the new user
-DECLARE @role1 NVARCHAR(MAX) = N'ALTER ROLE db_owner ADD MEMBER [' + @name + ']';
-EXEC (@role1);
+$command = $connection.CreateCommand()
+$command.CommandText = @'
+DECLARE @principalSid NVARCHAR(MAX) = CONVERT(VARCHAR(MAX), CONVERT(VARBINARY(16), @principalId), 1);
+DECLARE @pipelineIdentitySid NVARCHAR(MAX) = CONVERT(VARCHAR(MAX), CONVERT(VARBINARY(16), @pipelineIdentityClientId), 1);
 
--- Create pipeline identity user and assign role
-DECLARE @pipelineCmd NVARCHAR(MAX) = N'CREATE USER [' + @pipelineName + '] WITH SID = ' + @pipelineCastId + ', TYPE = E;'
-EXEC (@pipelineCmd);
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = @principalName)
+BEGIN
+    EXEC(N'CREATE USER ' + QUOTENAME(@principalName) + N' WITH SID = ' + @principalSid + N', TYPE = E;');
+END;
 
-DECLARE @pipelineRole NVARCHAR(MAX) = N'ALTER ROLE db_owner ADD MEMBER [' + @pipelineName + ']';
-EXEC (@pipelineRole);
+IF IS_ROLEMEMBER(N'db_owner', @principalName) <> 1
+BEGIN
+    EXEC(N'ALTER ROLE [db_owner] ADD MEMBER ' + QUOTENAME(@principalName) + N';');
+END;
 
-"@
-# Note: the string terminator must not have whitespace before it, therefore it is not indented.
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = @pipelineIdentityName)
+BEGIN
+    EXEC(N'CREATE USER ' + QUOTENAME(@pipelineIdentityName) + N' WITH SID = ' + @pipelineIdentitySid + N', TYPE = E;');
+END;
 
-Write-Host $sqlCmd
+IF IS_ROLEMEMBER(N'db_owner', @pipelineIdentityName) <> 1
+BEGIN
+    EXEC(N'ALTER ROLE [db_owner] ADD MEMBER ' + QUOTENAME(@pipelineIdentityName) + N';');
+END;
+'@
 
-$connectionString = "Server=tcp:${sqlServerFqdn},1433;Initial Catalog=${sqlDatabaseName};Authentication=Active Directory Default;"
+$null = $command.Parameters.Add('@principalName', [System.Data.SqlDbType]::NVarChar, 128)
+$command.Parameters['@principalName'].Value = $principalName
+$null = $command.Parameters.Add('@principalId', [System.Data.SqlDbType]::UniqueIdentifier)
+$command.Parameters['@principalId'].Value = $principalId
+$null = $command.Parameters.Add('@pipelineIdentityName', [System.Data.SqlDbType]::NVarChar, 128)
+$command.Parameters['@pipelineIdentityName'].Value = $pipelineIdentityName
+$null = $command.Parameters.Add('@pipelineIdentityClientId', [System.Data.SqlDbType]::UniqueIdentifier)
+$command.Parameters['@pipelineIdentityClientId'].Value = $pipelineIdentityClientId
 
-Invoke-Sqlcmd -ConnectionString $connectionString -Query $sqlCmd
+try {
+    $connection.Open()
+    $null = $command.ExecuteNonQuery()
+}
+finally {
+    $command.Dispose()
+    $connection.Dispose()
+}

--- a/infra/modules/sql.bicep
+++ b/infra/modules/sql.bicep
@@ -19,8 +19,14 @@ param azureAdAdministratorObjectId string
 @description('The Azure AD administrator Azure AD Tenant ID')
 param azureAdAdministratorTenantId string = subscription().tenantId
 
-@description('Subnet Resource ID for the infrastructure subnet')
+@description('Subnet Resource ID for the Container Apps environment')
 param subnetResourceId string
+
+@description('Name of the deployment-script storage account')
+param deploymentScriptStorageAccountName string
+
+@description('Subnet Resource ID used by the deployment-script Azure Container Instance')
+param deploymentScriptSubnetResourceId string
 
 @description('Managed Identity ID')
 param managedIdentityId string
@@ -59,6 +65,13 @@ resource sqlServer 'Microsoft.Sql/servers@2025-02-01-preview' = {
       virtualNetworkSubnetId: subnetResourceId
     }
   }
+
+  resource sqlDeploymentScriptsVirtualNetworkRules 'virtualNetworkRules' = {
+    name: 'sql-deployment-scripts-vnet-rules'
+    properties: {
+      virtualNetworkSubnetId: deploymentScriptSubnetResourceId
+    }
+  }
 }
 
 resource sqlDatabaseRoles 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
@@ -70,10 +83,24 @@ resource sqlDatabaseRoles 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
       '${managedIdentityId}': {}
     }
   }
+  dependsOn: [
+    sqlServer::sqlDatabase
+    sqlServer::sqlDeploymentScriptsVirtualNetworkRules
+  ]
   kind: 'AzurePowerShell'
   properties: {
     azPowerShellVersion: '14.4'
     retentionInterval: 'PT1H'
+    storageAccountSettings: {
+      storageAccountName: deploymentScriptStorageAccountName
+    }
+    containerSettings: {
+      subnetIds: [
+        {
+          id: deploymentScriptSubnetResourceId
+        }
+      ]
+    }
     environmentVariables: [
       {
         name: 'DBNAME'

--- a/infra/modules/virtualNetwork.bicep
+++ b/infra/modules/virtualNetwork.bicep
@@ -7,6 +7,9 @@ param tags object
 @description('Name of the compute subnet')
 param subnetName string
 
+@description('Name of the subnet used by deployment-script Azure Container Instances')
+param deploymentScriptsSubnetName string
+
 @description('Specifies the location for all resources.')
 param location string = resourceGroup().location
 
@@ -49,8 +52,43 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2025-05-01' = {
           ]
         }
       }
+      {
+        name: deploymentScriptsSubnetName
+        properties: {
+          addressPrefix: '10.0.0.32/27'
+          serviceEndpoints: [
+            {
+              service: 'Microsoft.Sql'
+              locations: [
+                'southafricanorth'
+              ]
+            }
+            {
+              service: 'Microsoft.KeyVault'
+              locations: [
+                'southafricanorth'
+              ]
+            }
+            {
+              service: 'Microsoft.Storage'
+              locations: [
+                'southafricanorth'
+              ]
+            }
+          ]
+          delegations: [
+            {
+              name: 'container-instance-delegation'
+              properties: {
+                serviceName: 'Microsoft.ContainerInstance/containerGroups'
+              }
+            }
+          ]
+        }
+      }
     ]
   }
 }
 
 output subnetId string = virtualNetwork.properties.subnets[0].id
+output deploymentScriptsSubnetId string = virtualNetwork.properties.subnets[1].id

--- a/infra/tests/test_redis_container_app.py
+++ b/infra/tests/test_redis_container_app.py
@@ -101,6 +101,58 @@ class RedisContainerAppInfrastructureTests(unittest.TestCase):
         self.assertIn('if [ -z "$secret_id" ]', generator)
         self.assertIn("output secretUrl string", generator)
 
+    def test_deployment_scripts_run_in_a_dedicated_aci_subnet_allowed_by_key_vault(self) -> None:
+        virtual_network = read("infra/modules/virtualNetwork.bicep")
+        key_vault = read("infra/modules/keyVault.bicep")
+        deployment_storage = read("infra/modules/deploymentScriptStorage.bicep")
+        generator = read("infra/modules/redisPassword.bicep")
+        sql = read("infra/modules/sql.bicep")
+        main = read("infra/main.bicep")
+
+        self.assertIn("deploymentScriptsSubnetId", virtual_network)
+        self.assertIn("10.0.0.32/27", virtual_network)
+        self.assertIn("Microsoft.ContainerInstance/containerGroups", virtual_network)
+        self.assertIn("Microsoft.KeyVault", virtual_network)
+        self.assertIn("Microsoft.Storage", virtual_network)
+        self.assertIn("deploymentScriptStorage", main)
+        self.assertIn("deploymentScriptStorageAccountName", main)
+        self.assertIn("deploymentScriptStorageAccountName", generator)
+        self.assertIn("storageAccountSettings", generator)
+        self.assertIn("deploymentScriptStorageAccountName", sql)
+        self.assertIn("storageAccountSettings", sql)
+        self.assertIn("storageFileDataPrivilegedContributor", generator)
+        self.assertIn("storageFileDataPrivilegedContributorRoleAssignment", generator)
+        self.assertIn("storageFileDataPrivilegedContributorRoleAssignment", deployment_storage)
+        self.assertIn("deploymentScriptIdentityPrincipalId", deployment_storage)
+        self.assertIn("deploymentScriptIdentityPrincipalId: managedIdentity.outputs.principalId", main)
+        self.assertIn("param subnetResourceIds array", key_vault)
+        self.assertIn("for subnetResourceId in subnetResourceIds", key_vault)
+        self.assertIn("param deploymentScriptSubnetResourceId string", generator)
+        self.assertIn("containerSettings", generator)
+        self.assertIn("id: deploymentScriptSubnetResourceId", generator)
+        self.assertIn("param deploymentScriptSubnetResourceId string", sql)
+        self.assertIn("sqlDeploymentScriptsVirtualNetworkRules", sql)
+        self.assertIn("virtualNetworkSubnetId: deploymentScriptSubnetResourceId", sql)
+        self.assertIn(
+            "dependsOn: [\n    sqlServer::sqlDatabase\n    sqlServer::sqlDeploymentScriptsVirtualNetworkRules\n  ]",
+            sql,
+        )
+        self.assertIn("containerSettings", sql)
+        self.assertIn("id: deploymentScriptSubnetResourceId", sql)
+        self.assertIn("deploymentScriptSubnetResourceId: virtualNetwork.outputs.deploymentScriptsSubnetId", main)
+        self.assertIn("subnetResourceIds: [", main)
+
+    def test_sql_deployment_script_uses_an_access_token_without_the_sqlserver_module(self) -> None:
+        sql_script = read("infra/modules/sql-deployment-script.ps1")
+
+        self.assertNotIn("Install-Module -Name SqlServer", sql_script)
+        self.assertNotIn("Import-Module SqlServer", sql_script)
+        self.assertNotIn("Invoke-Sqlcmd", sql_script)
+        self.assertIn("Get-AzAccessToken -ResourceUrl 'https://database.windows.net/'", sql_script)
+        self.assertIn("[System.Data.SqlClient.SqlConnection]", sql_script)
+        self.assertIn("AccessToken", sql_script)
+        self.assertIn("ExecuteNonQuery", sql_script)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Adds a dedicated delegated ACI subnet for deployment scripts, with SQL, Key Vault, and Storage service endpoints.
- Adds an Azure Firewall-compatible deployment-script storage account plus the least-privilege Storage File Data Privileged Contributor assignment required by VNet-connected deployment scripts.
- Runs both the Redis Key Vault password generator and SQL role-provisioning script in that subnet, and permits the subnet in the Key Vault and Azure SQL firewall rules.
- Replaces the failing `SqlServer`/`Invoke-Sqlcmd` path with direct token-authenticated `System.Data.SqlClient`, avoiding the Azure PowerShell 14 / SqlServer 22.3.0 Always Encrypted `MemoryCache` binary incompatibility.

## Validation
- `python3 -m unittest infra/tests/test_redis_container_app.py -v` — 8 passed
- `az bicep build --file infra/main.bicep`
- `az bicep build --file infra/api.bicep`
- `az bicep build --file infra/modules/deploymentScriptStorage.bicep`
- `az bicep build --file infra/modules/redisPassword.bicep`
- `az bicep build --file infra/modules/sql.bicep`
- `git diff --check`

## Rollout and rollback
- This is non-destructive: it retains Azure Managed Redis until the replacement deployment and application health checks complete.
- Azure Pipelines will be the first environment with deployment permissions to validate the VNet-connected scripts end-to-end.
- Rollback is a revert of this PR; the existing resources remain intact.

## Notes
- The local Hermes identity is intentionally Reader-only, so no What-If or Azure deployment was attempted.
- The SQL fix addresses the upstream failure documented in https://github.com/microsoft/aspire/issues/18893.