### PR TITLE
fix(infra): correct SQL deployment script dynamic execution

### DIFF
--- a/infra/modules/sql-deployment-script.ps1
+++ b/infra/modules/sql-deployment-script.ps1
@@ -26,25 +26,30 @@ $command = $connection.CreateCommand()
 $command.CommandText = @'
 DECLARE @principalSid NVARCHAR(MAX) = CONVERT(VARCHAR(MAX), CONVERT(VARBINARY(16), @principalId), 1);
 DECLARE @pipelineIdentitySid NVARCHAR(MAX) = CONVERT(VARCHAR(MAX), CONVERT(VARBINARY(16), @pipelineIdentityClientId), 1);
+DECLARE @sql NVARCHAR(MAX);
 
 IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = @principalName)
 BEGIN
-    EXEC(N'CREATE USER ' + QUOTENAME(@principalName) + N' WITH SID = ' + @principalSid + N', TYPE = E;');
+    SET @sql = N'CREATE USER ' + QUOTENAME(@principalName) + N' WITH SID = ' + @principalSid + N', TYPE = E;';
+    EXEC sys.sp_executesql @sql;
 END;
 
 IF IS_ROLEMEMBER(N'db_owner', @principalName) <> 1
 BEGIN
-    EXEC(N'ALTER ROLE [db_owner] ADD MEMBER ' + QUOTENAME(@principalName) + N';');
+    SET @sql = N'ALTER ROLE [db_owner] ADD MEMBER ' + QUOTENAME(@principalName) + N';';
+    EXEC sys.sp_executesql @sql;
 END;
 
 IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = @pipelineIdentityName)
 BEGIN
-    EXEC(N'CREATE USER ' + QUOTENAME(@pipelineIdentityName) + N' WITH SID = ' + @pipelineIdentitySid + N', TYPE = E;');
+    SET @sql = N'CREATE USER ' + QUOTENAME(@pipelineIdentityName) + N' WITH SID = ' + @pipelineIdentitySid + N', TYPE = E;';
+    EXEC sys.sp_executesql @sql;
 END;
 
 IF IS_ROLEMEMBER(N'db_owner', @pipelineIdentityName) <> 1
 BEGIN
-    EXEC(N'ALTER ROLE [db_owner] ADD MEMBER ' + QUOTENAME(@pipelineIdentityName) + N';');
+    SET @sql = N'ALTER ROLE [db_owner] ADD MEMBER ' + QUOTENAME(@pipelineIdentityName) + N';';
+    EXEC sys.sp_executesql @sql;
 END;
 '@
 

--- a/infra/tests/test_redis_container_app.py
+++ b/infra/tests/test_redis_container_app.py
@@ -153,6 +153,16 @@ class RedisContainerAppInfrastructureTests(unittest.TestCase):
         self.assertIn("AccessToken", sql_script)
         self.assertIn("ExecuteNonQuery", sql_script)
 
+    def test_sql_deployment_script_executes_dynamic_sql_from_a_variable(self) -> None:
+        sql_script = read("infra/modules/sql-deployment-script.ps1")
+
+        self.assertIn("DECLARE @sql NVARCHAR(MAX);", sql_script)
+        self.assertIn("SET @sql = N'CREATE USER '", sql_script)
+        self.assertIn("SET @sql = N'ALTER ROLE [db_owner] ADD MEMBER '", sql_script)
+        self.assertIn("EXEC sys.sp_executesql @sql;", sql_script)
+        self.assertNotIn("EXEC(N'CREATE USER ' +", sql_script)
+        self.assertNotIn("EXEC(N'ALTER ROLE [db_owner] ADD MEMBER ' +", sql_script)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- construct each dynamic `CREATE USER` and `ALTER ROLE` statement in `@sql`
- execute the variable through `sys.sp_executesql`, which Azure SQL accepts
- add a regression contract test rejecting the invalid `EXEC(<concatenation>)` pattern

## Validation
- `python3 -m unittest infra.tests.test_redis_container_app -v`
- `az bicep build --file infra/main.bicep --stdout`
- `git diff --check`

The full deployment remains Azure Pipelines-only because this identity intentionally has Reader access and cannot submit a resource deployment.