### PR TITLE
fix(infra): use Redis Container App name for internal host

### DIFF
--- a/infra/modules/redisContainerApp.bicep
+++ b/infra/modules/redisContainerApp.bicep
@@ -78,4 +78,4 @@ resource redisContainerApp 'Microsoft.App/containerApps@2026-01-01' = {
   }
 }
 
-output hostName string = redisContainerApp.properties.configuration.ingress.fqdn
+output hostName string = redisContainerApp.name

--- a/infra/tests/test_redis_container_app.py
+++ b/infra/tests/test_redis_container_app.py
@@ -35,6 +35,12 @@ class RedisContainerAppInfrastructureTests(unittest.TestCase):
         self.assertNotIn("output AZURE_REDIS_NAME", main)
         self.assertIn("output REDIS_CACHE_HOST_NAME string", main)
 
+    def test_redis_host_export_uses_container_app_name_for_internal_tcp_routing(self) -> None:
+        redis = read("infra/modules/redisContainerApp.bicep")
+
+        self.assertIn("output hostName string = redisContainerApp.name", redis)
+        self.assertNotIn("output hostName string = redisContainerApp.properties.configuration.ingress.fqdn", redis)
+
     def test_api_consumes_private_redis_host_and_key_vault_password(self) -> None:
         api = read("infra/api.bicep")
         parameters = read("infra/api.bicepparam")


### PR DESCRIPTION
## Summary
- Export the Redis Container App name instead of its internal ingress FQDN.
- Keep the Redis endpoint private while using Container Apps internal TCP service discovery.
- Add a regression contract test preventing a return to the ingress FQDN.

## Validation
- `python3 -m unittest infra.tests.test_redis_container_app.RedisContainerAppInfrastructureTests.test_redis_host_export_uses_container_app_name_for_internal_tcp_routing`
- `az bicep build --file infra/modules/redisContainerApp.bicep --stdout`
- `az bicep build --file infra/main.bicep --stdout`
- `git diff --check`

The full Azure deployment remains for Azure Pipelines to validate.
