### PR TITLE
fix: include infrastructure changes in API versioning

### DIFF
--- a/infra/tests/test_server_version_filters.py
+++ b/infra/tests/test_server_version_filters.py
@@ -1,0 +1,21 @@
+"""Regression tests for API versioning inputs."""
+
+from pathlib import Path
+import json
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class ServerVersionFilterTests(unittest.TestCase):
+    def test_server_version_tracks_infrastructure_changes(self) -> None:
+        version = json.loads(
+            (REPO_ROOT / "src/server/version.json").read_text(encoding="utf-8")
+        )
+
+        self.assertIn(":/infra", version["pathFilters"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/server/version.json
+++ b/src/server/version.json
@@ -2,7 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "6.0",
   "pathFilters": [
-    "."
+    ".",
+    ":/infra"
   ],
   "publicReleaseRefSpec": [
     "^refs/heads/main$",


### PR DESCRIPTION
## Summary
- Include repository-root `infra/` changes in the server Nerdbank.GitVersioning path filters.
- Add a regression test to prevent infrastructure-only deployments from reusing the previous API version/revision.

## Verification
- `python3 -m unittest infra.tests.test_server_version_filters -v`
- `git diff --check`

The full .NET validation could not run locally because the repository requires .NET SDK 10.0.400 and this environment has 10.0.111.