### PR TITLE
chore: remove obsolete Front Door deployment artifacts

### DIFF
--- a/.azdo/pipelines/azure-dev.yml
+++ b/.azdo/pipelines/azure-dev.yml
@@ -224,29 +224,6 @@ stages:
 
                 test "$customDomain" = "fakesurveygenerator.mysecondarydomain.com"
 
-          - task: AzureCLI@2
-            displayName: Remove Unused UI Container App
-            inputs:
-              azureSubscription: $(azureResourceManagerConnection)
-              scriptType: bash
-              scriptLocation: inlineScript
-              visibleAzLogin: false
-              inlineScript: |
-                set -euo pipefail
-
-                if az containerapp show \
-                  --name ca-fake-survey-generator-ui \
-                  --resource-group $(azureResourceGroup) \
-                  --output none 2>/dev/null; then
-                  az containerapp delete \
-                    --name ca-fake-survey-generator-ui \
-                    --resource-group $(azureResourceGroup) \
-                    --yes
-                else
-                  echo "Unused UI Container App is already absent"
-                fi
-
-
   - stage: Database_Deployment
     condition: and(succeeded(), eq(variables.isMain, true))
     dependsOn:

--- a/infra/abbreviations.json
+++ b/infra/abbreviations.json
@@ -73,8 +73,6 @@
   "networkFirewallPolicies": "afwp-",
   "networkFirewallPoliciesWebApplication": "waf",
   "networkFirewallPoliciesRuleGroups": "wafrg",
-  "networkFrontDoors": "fd-",
-  "networkFrontdoorWebApplicationFirewallPolicies": "fdfp-",
   "networkLoadBalancersExternal": "lbe-",
   "networkLoadBalancersInternal": "lbi-",
   "networkLoadBalancersInboundNatRules": "rule-",

--- a/infra/modules/containerAppEnvironment.bicep
+++ b/infra/modules/containerAppEnvironment.bicep
@@ -40,68 +40,6 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2026-01-01' 
     ]
   }
 
-  // resource managedCertificate 'managedCertificates' = {
-  //   name: 'fake-survey-generator-cert'
-  //   location: location
-  //   tags: tags
-  //   properties: {
-  //     subjectName: 'fakesurveygeneratortest.mysecondarydomain.com'
-  //     domainControlValidation: 'TXT'
-  //   }
-  //   dependsOn: [
-  //     httpRouteConfig
-  //   ]
-  // }
-
-  resource httpRouteConfig 'httpRouteConfigs' = {
-    name: 'fakesurveygenerator'
-    properties: {
-      customDomains: [
-        {
-          name: 'fakesurveygeneratortest.mysecondarydomain.com'
-          bindingType: 'Auto'
-        }
-      ]
-      rules: [
-        {
-          description: 'API Rule'
-          routes: [
-            {
-              match: {
-                prefix: '/api'
-              }
-            }
-            {
-              match: {
-                prefix: '/api-docs'
-              }
-              action: {
-                prefixRewrite: '/'
-              }
-            }
-            {
-              match: {
-                prefix: '/openapi'
-              }
-              action: {
-                prefixRewrite: '/'
-              }
-            }
-            {
-              match: {
-                prefix: '/'
-              }
-            }
-          ]
-          targets: [
-            {
-              containerApp: 'ca-fake-survey-generator-api'
-            }
-          ]
-        }
-      ]
-    }
-  }
 }
 
 output containerAppEnvironmentId string = containerAppEnvironment.id

--- a/infra/tests/test_consolidated_frontend.py
+++ b/infra/tests/test_consolidated_frontend.py
@@ -46,10 +46,8 @@ class ConsolidatedFrontendTests(unittest.TestCase):
         self.assertNotIn("asuid.fakesurveygenerator.mysecondarydomain.com", pipeline)
         self.assertNotIn("existingVerificationId", pipeline)
         self.assertNotIn("if [ \"$existingVerificationId\" != \"$verificationId\" ]", pipeline)
-        self.assertIn("Remove Unused UI Container App", pipeline)
-        self.assertIn("az containerapp delete", pipeline)
-        self.assertIn("ca-fake-survey-generator-ui", pipeline)
-        self.assertIn("--yes", pipeline)
+        self.assertNotIn("Remove Unused UI Container App", pipeline)
+        self.assertNotIn("ca-fake-survey-generator-ui", pipeline)
         self.assertIn("Verify Container App Custom Domain", pipeline)
         self.assertIn("properties.configuration.ingress.customDomains", pipeline)
         self.assertEqual(pipeline.count("azd deploy --no-prompt"), 1)
@@ -99,7 +97,8 @@ class ConsolidatedFrontendTests(unittest.TestCase):
         self.assertIn("output DNS_ZONE_NAME", main)
         self.assertIn("output CUSTOM_DOMAIN_NAME", main)
         self.assertNotIn("ca-fake-survey-generator-ui", environment)
-        self.assertIn("prefix: '/'", environment)
+        self.assertNotIn("httpRouteConfig", environment)
+        self.assertNotIn("fakesurveygeneratortest.mysecondarydomain.com", environment)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Remove the no-longer-needed UI Container App cleanup task from the deployment pipeline.
- Remove stale Container Apps environment HTTP route configuration left over from the former Front Door architecture.
- Remove unused Front Door abbreviation entries.
- Update infrastructure contract tests to enforce the final direct Container App architecture.

## Verification
- `python3 -m unittest discover -s infra/tests -p 'test_*.py' -v` (15 passed)\n- `az bicep build --file infra/main.bicep --stdout`\n- `az bicep build --file infra/modules/containerAppEnvironment.bicep --stdout`\n- `git diff --check`\n\nNo Azure resources were changed.